### PR TITLE
fix compile error in python3 env (ros neotic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 include_directories(include ${Boost_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include/numpy_eigen")
-add_definitions(-std=c++0x -D__STRICT_ANSI__)
+add_definitions(-std=c++0x -fpermissive -D__STRICT_ANSI__)
 
 INCLUDE(src/autogen_files.cmake)
 add_python_export_library(${PROJECT_NAME} 


### PR DESCRIPTION
Reference from https://github.com/chrischoy/knn_cuda/issues/8,  the releted error information is:

numpy/core/include/numpy/__multiarray_api.h:1541:35: error: return-statement with a value, in function returning 'void' [-fpermissive]
 #define NUMPY_IMPORT_ARRAY_RETVAL NULL
                                   ^